### PR TITLE
Partial Solution

### DIFF
--- a/controllers/event-controller.js
+++ b/controllers/event-controller.js
@@ -1,0 +1,32 @@
+(function(exports) {
+  function EventController(headlineElement, storyElement) {
+    this._headlineElement = headlineElement;
+    this._storyElement = storyElement;
+  }
+
+  EventController.prototype.actionOnLoadPage = function (requestController) {
+    requestController.requestHeadlines();
+    window.addEventListener("hashchange", this.actionOnHashChange);
+  };
+
+  EventController.prototype.actionOnLoadHeadlines = function () {
+    var headlines = new Headlines(JSON.parse(this.responseText).response.results); // Bind this
+    var headlinesView = new HeadlinesView(headlines);
+    var headlinesController = new HeadlinesController(headlinesView, this._headlineElement) // Don't bind this
+    headlinesController.insertHTML();
+  };
+
+  EventController.prototype.actionOnLoadStory = function () {
+    var story = new Story(JSON.parse(this.response).response.content); // Bind this
+    var storyView = new StoryView(story);
+    var storyController = new StoryController(storyView, this._storyElement); // Don't bind this
+    storyController.insertHTML();
+  };
+
+  EventController.prototype.actionOnHashChange = function (requestController) {
+     requestController.requestStory();
+  };
+
+  exports.EventController = EventController;
+
+})(this);

--- a/controllers/headlines-controller.js
+++ b/controllers/headlines-controller.js
@@ -1,0 +1,22 @@
+(function(exports) {
+
+  function HeadlinesController(headlinesView, element) {
+    this._headlinesView = headlinesView;
+    this._element = element;
+  };
+
+  HeadlinesController.prototype.headlinesView = function () {
+    return this._headlinesView;
+  };
+
+  HeadlinesController.prototype.element = function () {
+    return this._element;
+  };
+
+  HeadlinesController.prototype.insertHTML = function() {
+    this._element.innerHTML = this._headlinesView.parse();
+  };
+
+  exports.HeadlinesContoller = HeadlinesController;
+
+})(this)

--- a/controllers/headlines-controller.js
+++ b/controllers/headlines-controller.js
@@ -17,6 +17,6 @@
     this._element.innerHTML = this._headlinesView.parse();
   };
 
-  exports.HeadlinesContoller = HeadlinesController;
+  exports.HeadlinesController = HeadlinesController;
 
 })(this)

--- a/controllers/request-controller.js
+++ b/controllers/request-controller.js
@@ -1,0 +1,26 @@
+(function(exports) {
+  function RequestController(eventController) {
+    this._eventController = eventController;
+  }
+
+  RequestController.prototype.requestHeadlines = function () {
+    var headlinesRequest = new XMLHttpRequest();
+    headlinesRequest.addEventListener("load", eventController.actionOnLoadHeadlines) // actionOnLoadHeadlines
+    headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news?show-fields=thumbnail");
+    headlinesRequest.send();
+  };
+
+  RequestController.prototype.requestStory = function () {
+    var storyRequest = new XMLHttpRequest();
+    storyRequest.addEventListener("load", eventController.actionOnLoadStory) // actionOnLoadStory
+    storyRequest.open("GET", `http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/${this._getIdFromURL()}?show-fields=all`);
+    storyRequest.send();
+  };
+
+  RequestController.prototype._getIdFromURL = function () {
+    return window.location.hash.split('/').slice(1).join('/');
+  };
+
+  exports.RequestController = RequestController;
+
+})(this);

--- a/controllers/story-controller.js
+++ b/controllers/story-controller.js
@@ -1,0 +1,21 @@
+(function(exports) {
+
+  function StoryController(storyView, element) {
+    this._storyView = storyView;
+    this._element = element;
+  }
+
+  StoryController.prototype.storyView = function () {
+    return this._storyView;
+  };
+
+  StoryController.prototype.element = function () {
+    return this._element;
+  };
+
+  StoryController.prototype.insertHTML = function () {
+    this._element.innerHTML = this._storyView.parse();
+  };
+
+  exports.StoryController = StoryController;
+})(this);

--- a/index.html
+++ b/index.html
@@ -72,13 +72,6 @@
         return window.location.hash.split('/').slice(1).join('/');
       };
 
-      // var headlinesRequest = new XMLHttpRequest();
-      // headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
-      // headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
-      // headlinesRequest.send();
-
-      // window.addEventListener("hashchange", actionOnHashChange);
-
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -24,55 +24,8 @@
     <script src="controllers/headlines-controller.js"></script>
     <script src="controllers/story-controller.js"></script>
 
-    <script>
+    <!-- app -->
+    <script src="index.js"></script>
 
-      var headlines;
-      var headlinesView;
-      var headlinesController;
-      var headlineElement = document.getElementById('headlines');
-      var story;
-      var storyView;
-      var storyController;
-      var storyElement = document.getElementById('story');
-
-      listenForHashChange();
-
-      function listenForHashChange () {
-        window.addEventListener("hashchange", actionOnHashChange);
-      }
-
-      function actionOnLoadPage () {
-        var headlinesRequest = new XMLHttpRequest();
-        headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
-        headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news?show-fields=thumbnail");
-        headlinesRequest.send();
-      }
-
-      function actionOnLoadHeadlines () {
-        headlines = new Headlines(JSON.parse(this.responseText).response.results);
-        headlinesView = new HeadlinesView(headlines);
-        headlinesController = new HeadlinesController(headlinesView, headlineElement);
-        headlinesController.insertHTML();
-      };
-
-      function actionOnLoadStory () {
-        story = new Story(JSON.parse(this.response).response.content);
-        storyView = new StoryView(story);
-        storyController = new StoryController(storyView, storyElement);
-        storyController.insertHTML();
-      }
-
-      function actionOnHashChange () {
-        var summaryRequest = new XMLHttpRequest();
-        summaryRequest.addEventListener("load", actionOnLoadStory);
-        summaryRequest.open("GET", `http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/${getIdFromURL()}?show-fields=all`)
-        summaryRequest.send();
-      };
-
-      function getIdFromURL() {
-        return window.location.hash.split('/').slice(1).join('/');
-      };
-
-    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 
     <h1>Headlines</h1>
     <div id="headlines"></div>
+    <hr>
 
     <div id="story"></div>
 
@@ -43,7 +44,7 @@
       function actionOnLoadPage () {
         var headlinesRequest = new XMLHttpRequest();
         headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
-        headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
+        headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news?show-fields=thumbnail");
         headlinesRequest.send();
       }
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>News</title>
   </head>
   <body>
+    <h1>Headlines</h1>
     <div id="headlines"></div>
 
     <!-- models -->

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>News</title>
+  </head>
+  <body>
+    <div id="headlines"></div>
+
+    <!-- models -->
+    <script src="models/headlines-model.js">Model</script>
+
+    <!-- views -->
+    <script src="views/headlines-view.js">View</script>
+
+    <!-- controllers -->
+    <script src="controllers/headlines-controller.js">Controller</script>
+
+    <script>
+
+      var headlines;
+      var headlinesView;
+      var headlinesController;
+      var headlineElement = document.getElementById('headlines')
+
+      function reqListener () {
+        console.log(JSON.parse(this.responseText).response.results)
+        headlines = new Headlines(JSON.parse(this.responseText).response.results);
+        headlinesView = new HeadlinesView(headlines);
+        headlinesController = new HeadlinesController(headlinesView, headlineElement);
+        headlinesController.insertHTML();
+      }
+
+      var oReq = new XMLHttpRequest();
+      oReq.addEventListener("load", reqListener);
+      oReq.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
+      oReq.send();
+
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
     <div id="headlines"></div>
 
     <!-- models -->
-    <script src="models/headlines-model.js">Model</script>
+    <script src="models/headlines-model.js"></script>
 
     <!-- views -->
-    <script src="views/headlines-view.js">View</script>
+    <script src="views/headlines-view.js"></script>
 
     <!-- controllers -->
-    <script src="controllers/headlines-controller.js">Controller</script>
+    <script src="controllers/headlines-controller.js"></script>
 
     <script>
 

--- a/index.html
+++ b/index.html
@@ -4,38 +4,80 @@
     <meta charset="utf-8">
     <title>News</title>
   </head>
-  <body>
+  <body onload="actionOnLoadPage()">
+
     <h1>Headlines</h1>
     <div id="headlines"></div>
 
+    <div id="story"></div>
+
     <!-- models -->
     <script src="models/headlines-model.js"></script>
+    <script src="models/story-model.js"></script>
 
     <!-- views -->
     <script src="views/headlines-view.js"></script>
+    <script src="views/story-view.js"></script>
 
     <!-- controllers -->
     <script src="controllers/headlines-controller.js"></script>
+    <script src="controllers/story-controller.js"></script>
 
     <script>
 
       var headlines;
       var headlinesView;
       var headlinesController;
-      var headlineElement = document.getElementById('headlines')
+      var headlineElement = document.getElementById('headlines');
+      var story;
+      var storyView;
+      var storyController;
+      var storyElement = document.getElementById('story');
 
-      function reqListener () {
-        console.log(JSON.parse(this.responseText).response.results)
+      listenForHashChange();
+
+      function listenForHashChange () {
+        window.addEventListener("hashchange", actionOnHashChange);
+      }
+
+      function actionOnLoadPage () {
+        var headlinesRequest = new XMLHttpRequest();
+        headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
+        headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
+        headlinesRequest.send();
+      }
+
+      function actionOnLoadHeadlines () {
         headlines = new Headlines(JSON.parse(this.responseText).response.results);
         headlinesView = new HeadlinesView(headlines);
         headlinesController = new HeadlinesController(headlinesView, headlineElement);
         headlinesController.insertHTML();
+      };
+
+      function actionOnLoadStory () {
+        story = new Story(JSON.parse(this.response).response.content);
+        storyView = new StoryView(story);
+        storyController = new StoryController(storyView, storyElement);
+        storyController.insertHTML();
       }
 
-      var oReq = new XMLHttpRequest();
-      oReq.addEventListener("load", reqListener);
-      oReq.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
-      oReq.send();
+      function actionOnHashChange () {
+        var summaryRequest = new XMLHttpRequest();
+        summaryRequest.addEventListener("load", actionOnLoadStory);
+        summaryRequest.open("GET", `http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/${getIdFromURL()}?show-fields=all`)
+        summaryRequest.send();
+      };
+
+      function getIdFromURL() {
+        return window.location.hash.split('/').slice(1).join('/');
+      };
+
+      // var headlinesRequest = new XMLHttpRequest();
+      // headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
+      // headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news");
+      // headlinesRequest.send();
+
+      // window.addEventListener("hashchange", actionOnHashChange);
 
     </script>
   </body>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,45 @@
+var headlines;
+var headlinesView;
+var headlinesController;
+var headlineElement = document.getElementById('headlines');
+var story;
+var storyView;
+var storyController;
+var storyElement = document.getElementById('story');
+
+function listenForHashChange () {
+  window.addEventListener("hashchange", actionOnHashChange);
+}
+
+function actionOnLoadPage () {
+  var headlinesRequest = new XMLHttpRequest();
+  headlinesRequest.addEventListener("load", actionOnLoadHeadlines);
+  headlinesRequest.open("GET", "http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/uk-news?show-fields=thumbnail");
+  headlinesRequest.send();
+  listenForHashChange();
+}
+
+function actionOnLoadHeadlines () {
+  headlines = new Headlines(JSON.parse(this.responseText).response.results);
+  headlinesView = new HeadlinesView(headlines);
+  headlinesController = new HeadlinesController(headlinesView, headlineElement);
+  headlinesController.insertHTML();
+};
+
+function actionOnLoadStory () {
+  story = new Story(JSON.parse(this.response).response.content);
+  storyView = new StoryView(story);
+  storyController = new StoryController(storyView, storyElement);
+  storyController.insertHTML();
+}
+
+function actionOnHashChange () {
+  var summaryRequest = new XMLHttpRequest();
+  summaryRequest.addEventListener("load", actionOnLoadStory);
+  summaryRequest.open("GET", `http://news-summary-api.herokuapp.com/guardian?apiRequestUrl=http://content.guardianapis.com/${getIdFromURL()}?show-fields=all`)
+  summaryRequest.send();
+};
+
+function getIdFromURL() {
+  return window.location.hash.split('/').slice(1).join('/');
+};

--- a/models/headlines-model.js
+++ b/models/headlines-model.js
@@ -1,0 +1,12 @@
+(function(exports) {
+
+  function Headlines(headlines) {
+    this._headlines = headlines;
+  };
+
+  Headlines.prototype.headlines = function () {
+    return this._headlines;
+  };
+
+  exports.Headlines = Headlines;
+})(this)

--- a/models/story-model.js
+++ b/models/story-model.js
@@ -1,0 +1,13 @@
+(function(exports) {
+
+  function Story(story) {
+    this._story = story;
+  }
+
+  Story.prototype.story = function () {
+    return this._story;
+  };
+
+  exports.Story = Story;
+
+})(this);

--- a/models/story-model.js
+++ b/models/story-model.js
@@ -1,11 +1,31 @@
 (function(exports) {
 
   function Story(story) {
-    this._story = story;
+    this._headline = story.fields.headline;
+    this._thumbnail = story.fields.thumbnail;
+    this._trailText = story.fields.trailText;
+    this._byline = story.fields.byline;
+    this._body = story.fields.body;
   }
 
-  Story.prototype.story = function () {
-    return this._story;
+  Story.prototype.headline = function () {
+    return this._headline;
+  };
+
+  Story.prototype.thumbnail = function () {
+    return this._thumbnail;
+  };
+
+  Story.prototype.trailText = function () {
+    return this._trailText;
+  };
+
+  Story.prototype.byline = function () {
+    return this._byline;
+  };
+
+  Story.prototype.body = function () {
+    return this._body;
   };
 
   exports.Story = Story;

--- a/spec.html
+++ b/spec.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Spec</title>
+
+    <!-- models -->
+    <script src="models/headlines-model.js">Model</script>
+
+    <!-- views -->
+    <script src="views/headlines-view.js">View</script>
+
+    <!-- controllers -->
+    <script src="controllers/headlines-controller.js">Controller</script>
+
+    <!-- test framework -->
+    <script src="test/assert.js"></script>
+    <script src="test/test.js"></script>
+    <script src="test/drive.js"></script>
+
+    <!-- specs -->
+
+
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/assert.js
+++ b/test/assert.js
@@ -1,0 +1,39 @@
+var assert = {
+
+  isTrue: function(assertionToCheck, name) {
+    if (!assertionToCheck) {
+      throw Error(`Fail: ${name}. Expected true but received ${assertionToCheck}.`);
+    };
+  },
+
+  isA: function(instance, type, name) {
+    if (!(instance instanceof type)) {
+      throw Error(`Fail ${name}. Expected ${type.name} but received ${instance.constructor.name}.`);
+    };
+  },
+
+  isEqual: function(instance1, instance2, name) {
+    if (instance1 !== instance2) {
+      throw Error(`Fail ${name}. Expected ${instance1} to equal ${instance2}.`);
+    };
+  },
+
+  isEmpty: function(array, name) {
+    if (array.length !== 0) {
+      throw Error(`Fail ${name}. Expected ${array} to be empty but length was ${array.length}.`);
+    };
+  },
+
+  contains: function(array, item, name) {
+    if (!array.includes(item)) {
+      throw Error(`Fail ${name}. Expected ${array} to include ${item} but contained ${array}`);
+    };
+  },
+
+  is0: function(number, name) {
+    if(number !== 0) {
+      throw Error(`Fail ${name}. Expected ${number} to equal 0.`);
+    };
+  }
+
+};

--- a/test/drive.js
+++ b/test/drive.js
@@ -1,0 +1,5 @@
+var drive = function(blah, tests) {
+  console.log(blah);
+  tests();
+  console.log("");
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,13 @@
+var test = {
+
+  unit: function(description, test) {
+    test();
+    console.log(` - ${description}`);
+  },
+
+  feature: function(description, test) {
+    test();
+    console.log(` - ${description}`);
+  }
+
+};

--- a/views/headlines-view.js
+++ b/views/headlines-view.js
@@ -8,10 +8,10 @@
   };
 
   HeadlinesView.prototype.parse = function() {
-    string = "<ul>";
+    var string = "<ul>";
 
     this._headlines.headlines().forEach(function(headline) {
-      string += `<li><div>${headline.webTitle}</div></li>`;
+      string += `<li><div><a href='#summary/${headline.id}'>${headline.webTitle}</div></li>`;
     });
 
     string += "</ul>";

--- a/views/headlines-view.js
+++ b/views/headlines-view.js
@@ -1,0 +1,23 @@
+(function(exports) {
+  function HeadlinesView(headlines) {
+    this._headlines = headlines;
+  };
+
+  HeadlinesView.prototype.headlines = function () {
+    return this._headlines;
+  };
+
+  HeadlinesView.prototype.parse = function() {
+    string = "<ul>";
+
+    this._headlines.headlines().forEach(function(headline) {
+      string += `<li><div><${headline.webTitle}</div></li>`;
+    });
+
+    string += "</ul>";
+    return string;
+  };
+
+  exports.HeadlinesView = HeadlinesView;
+
+})(this);

--- a/views/headlines-view.js
+++ b/views/headlines-view.js
@@ -8,10 +8,13 @@
   };
 
   HeadlinesView.prototype.parse = function() {
-    var string = "<ul>";
+    var string = '<ul style="list-style: none;">';
 
     this._headlines.headlines().forEach(function(headline) {
-      string += `<li><div><a href='#summary/${headline.id}'>${headline.webTitle}</div></li>`;
+      string += `<h3><li><div><a href='#summary/${headline.id}'>`;
+      string += `${headline.webTitle}</a><br>`
+      string += `<img src="${headline.fields.thumbnail}">`
+      string += `</div></li></h3>`;
     });
 
     string += "</ul>";

--- a/views/headlines-view.js
+++ b/views/headlines-view.js
@@ -11,7 +11,7 @@
     string = "<ul>";
 
     this._headlines.headlines().forEach(function(headline) {
-      string += `<li><div><${headline.webTitle}</div></li>`;
+      string += `<li><div>${headline.webTitle}</div></li>`;
     });
 
     string += "</ul>";

--- a/views/headlines-view.js
+++ b/views/headlines-view.js
@@ -11,9 +11,9 @@
     var string = '<ul style="list-style: none;">';
 
     this._headlines.headlines().forEach(function(headline) {
-      string += `<h3><li><div><a href='#summary/${headline.id}'>`;
-      string += `${headline.webTitle}</a><br>`
-      string += `<img src="${headline.fields.thumbnail}">`
+      string += `<h3><li><div><img src="${headline.fields.thumbnail}"><br>`;
+      string += `<a href='#summary/${headline.id}'>`;
+      string += `${headline.webTitle}</a>`;
       string += `</div></li></h3>`;
     });
 

--- a/views/story-view.js
+++ b/views/story-view.js
@@ -1,0 +1,21 @@
+(function(exports) {
+
+  function StoryView(story) {
+    this._story = story;
+  }
+
+  StoryView.prototype.story = function () {
+    return this._story;
+  };
+
+  StoryView.prototype.parse = function () {
+    string = `<h1>${this._story.story().fields.headline}</h1>`;
+    string += `<h2>${this._story.story().fields.trailText}</h2>`;
+    string += `<h3>${this._story.story().fields.byline}</h3>`;
+    string += this._story.story().fields.body;
+    return string;
+  };
+
+  exports.StoryView = StoryView;
+
+})(this);

--- a/views/story-view.js
+++ b/views/story-view.js
@@ -10,6 +10,7 @@
 
   StoryView.prototype.parse = function () {
     string = `<h1>${this._story.story().fields.headline}</h1>`;
+    string += `<img src="${this._story.story().fields.thumbnail}">`;
     string += `<h2>${this._story.story().fields.trailText}</h2>`;
     string += `<h3>${this._story.story().fields.byline}</h3>`;
     string += this._story.story().fields.body;

--- a/views/story-view.js
+++ b/views/story-view.js
@@ -9,11 +9,11 @@
   };
 
   StoryView.prototype.parse = function () {
-    string = `<h1>${this._story.story().fields.headline}</h1>`;
-    string += `<img src="${this._story.story().fields.thumbnail}">`;
-    string += `<h2>${this._story.story().fields.trailText}</h2>`;
-    string += `<h3>${this._story.story().fields.byline}</h3>`;
-    string += this._story.story().fields.body;
+    string = `<h1>${this._story.headline()}</h1>`;
+    string += `<img src="${this._story.thumbnail()}">`;
+    string += `<h2>${this._story.trailText()}</h2>`;
+    string += `<h3>${this._story.byline()}</h3>`;
+    string += this._story.body();
     return string;
   };
 


### PR DESCRIPTION
This solution met the first four user stories using a hacky, untested solution with the caveats below.

I was limited on time so implemented as many features as I could as quickly as I could. 

- The work of handling requests and events is done in a script in index.html. This should be extracted out into controllers/handlers.
- The Aylien API had reached its request limit by the time I tried to use it. Instead, I extracted the content of the stories from the Guardian API. So they are not really summaries.
-  The site is very plain and is not responsive to the user's screen size.
- There are no animations.
- I didn't write a readme.